### PR TITLE
ScheduleMatch now receives correct name for author of post.

### DIFF
--- a/classic_tetris_project/commands/schedulematch.py
+++ b/classic_tetris_project/commands/schedulematch.py
@@ -24,7 +24,13 @@ class ScheduleMatch(Command):
         # only accept reports in the reporting channel
         if not checkChannelPeon(self.context):
             return
-        league, result = processRequest(self.context.author.nick, self.context.message.content)
+        
+        # preference for names. Nickname, display_name.
+        name = (self.context.author.nick or 
+               self.context.author.display_name or 
+               str(self.context.author))
+
+        league, result = processRequest(name, self.context.message.content)
         temp_message = self.send_message("```" + result + "```")
         if league is not None:
             self.context.add_reaction(self.context.message, '🇦')


### PR DESCRIPTION
Fixed bug with schedulematch receiving wrong post author.