### PR TITLE
Use frames-1 for calculating Hz

### DIFF
--- a/classic_tetris_project/util/fieldgen/hz_simulation.py
+++ b/classic_tetris_project/util/fieldgen/hz_simulation.py
@@ -66,7 +66,7 @@ class HzSimulation:
         return indices
 
     def hertz(self):
-        mini = round(60 * (self.taps - 1) / self.frames, 2)
+        mini = round(60 * (self.taps - 1) / (self.frames - 1), 2)
         maxi = round(60 * self.taps / self.frames, 2)
 
         return (mini, maxi)


### PR DESCRIPTION
I know that Hz is a controversial topic, but hear me out on this one.

I believe the existing formula gives results that are unintuitive for non-experts on Hz. An example (the inspiration for this PR) is this result:

> 5 taps 7 high on level 19:
> 10.0 - 12.5 Hz
> Sample input sequence: X....X.....X.....X.....X

This result to an untrained eye would indicate that DAS (10 Hz) would be able to make it over 7 left without a quicktap, which most players know isn't true. But DAS is 10 Hz, and it times the start and end taps frame-perfectly, so judging by the second line of the output, it should be able to make it. I was really confused when I saw this, especially because the input sequence shown don't appear to match what we typically think of as 10 Hz (one of the gaps is smaller than 5 frames). The input sequence is correct of course, but having the 10 number there is confusing.

After some discussion with Xeal, we've agreed on three formulas for Hz which are "correct" in different ways:

- **taps/frames**- the current "max", this is uncontroversial
- **(taps-1)/frames** - gives 10.0 in the example above, and represents the *absolute*, *non-inclusive* lower bound, including unintuitive subframe timings.
- **(taps-1)/(frames-1)** - gives 10.43 Hz, and represents the *inclusive* minimum Hz, not including subframe timings.

I think most Tetris players would get more meaning out of the display 
> 10.43 - 12.5 Hz

which indicates that 
1) DAS at 10 Hz is not fast enough to clear over 7, and 
2) If your "raw Hz" (average if you tapped for a long time continuously) is 10.43 Hz, the piece will make it over if you time it on the right frame (most players don't know about subframe timings).

That's my case. I know it might not appease the most technical players out there, but consider that this bot command is going to be used mostly by people without much technical understanding. They won't know that the sequence `X....X.....X.....X.....X` could *technically* be interpreted as 10.001 Hz if you just so happened to be on the earliest nanosecond of the first X and the last nanosecond of the last X. They will see the 10 - 12.5 and think that 10 Hz is enough to make it over.

For that reason, I think the **(taps-1)/(frames-1)** formula gives more intuitive results for the average player. Thanks for coming to my TED talk.