### PR TITLE
[WIP] Bracket visualization prototype

### DIFF
--- a/classic_tetris_project/facades/tournament_match_display.py
+++ b/classic_tetris_project/facades/tournament_match_display.py
@@ -57,13 +57,11 @@ class TournamentMatchDisplay:
                                                  self.tournament_match.source2_data)
 
     def player1_color(self):
-        player_count = self.tournament_match.tournament.seed_count
-        return self.get_color_for_player_index(player_count, self.tournament_match, 1)
+        return self.get_color_for_player_index(self.tournament_match, 1)
 
 
     def player2_color(self):
-        player_count = self.tournament_match.tournament.seed_count
-        return self.get_color_for_player_index(player_count, self.tournament_match, 0)
+        return self.get_color_for_player_index(self.tournament_match, 0)
 
     @staticmethod
     def generate_round(match_count, all_matches):
@@ -79,16 +77,20 @@ class TournamentMatchDisplay:
         return new_matches
 
     @staticmethod
-    def get_color_for_player_index(player_count, match, player_position):
-        round_num = match.round_number
-        adjusted_round_num = round_num if (player_count & (player_count-1) == 0) and player_count != 0 else round_num - 1
-        adjusted_round_num = adjusted_round_num or 1
-
+    def get_color_for_player_index(match, player_position):
         player_count = match.tournament.seed_count
-        adjusted_player_count = TournamentMatchDisplay.highest_power_of_2(player_count)
-        color_section_count = adjusted_player_count / 4
-        match_num = match.match_number
+        round_num = match.round_number
+        is_power_of_2 = (player_count & (player_count-1) == 0) and player_count != 0
+        adjusted_round_num = round_num if is_power_of_2 else round_num - 1
 
+        if adjusted_round_num <= 0:
+            return 5
+
+        adjusted_player_count = TournamentMatchDisplay.highest_power_of_2(player_count)
+        adjusted_count_discrepancy = player_count - adjusted_player_count
+
+        color_section_count = adjusted_player_count / 4
+        match_num = match.match_number - adjusted_count_discrepancy
 
         mod_value = (adjusted_player_count / 2**(adjusted_round_num-1)) if adjusted_round_num > 1 else adjusted_player_count
         player_index = (match_num * 2 - player_position) % mod_value or mod_value


### PR DESCRIPTION
Adds bracket visualization prototype to tournament pages.

This is still WIP and interested in thoughts here before continuing with more clean up. 

Summary:

I am basically just iterating through the match list and building a pseudo-tree.  Then by some complicated logic I am determining the split of what should be colorized to which of the four colors of the bracket system.

Caveats/uncertainties:

- I am currently not colorizing the first round of matches if they are "feed in" matches because I am struggling to think of the right way to do that.  Maybe once my brain is less fried I'll be able to come back and figure that out.

- I really feel like I am being dumb with my approach here for the color assignment in particular - there is likely a much cleaner approach to this and what I came up with absolutely is confusing and hard to follow.  Kind of embarrassed by what I came up with but... maybe when my brain is less fried I'll come back with a better approach.

- This code could probably be structured better and maybe some of the code should be abstracted away from  `TournamentMatchDisplay` .

- I bumped the `max-width` of `main-content` up to 1200px, but curious for thoughts there.  This was to help with brackets above 16 players.


Nevertheless.... it does kinda sorta work!


![Screenshot 2022-03-04 201626](https://user-images.githubusercontent.com/1138903/156865848-3a6029b5-dea5-4a9c-b3a4-2436bee29901.png)

