### PR TITLE
Try to prevent caching of redirects

### DIFF
--- a/classic_tetris_project/models/custom_redirect.py
+++ b/classic_tetris_project/models/custom_redirect.py
@@ -1,0 +1,8 @@
+from django.http import HttpResponseRedirect
+from django.contrib.redirects.middleware import RedirectFallbackMiddleware
+
+class HttpResponseTemporaryRedirect(HttpResponseRedirect):
+  status_code = 307
+
+class CustomRedirect(RedirectFallbackMiddleware):
+  response_redirect_class = HttpResponseTemporaryRedirect

--- a/classic_tetris_project_django/settings.py
+++ b/classic_tetris_project_django/settings.py
@@ -86,7 +86,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.contrib.redirects.middleware.RedirectFallbackMiddleware',
+    'classic_tetris_project.models.custom_redirect.CustomRedirect',
     'rollbar.contrib.django.middleware.RollbarNotifierMiddleware',
 ]
 


### PR DESCRIPTION
This is affecting things like the changing `/qual` URL each month.  I figured we might as well make these 307, which appear to not cache by default.

Not sure if this is the right Django way to override middleware though, so let me know what you think.