### PR TITLE
Allow seed command to be used in Discord without mod check

### DIFF
--- a/classic_tetris_project/commands/utility.py
+++ b/classic_tetris_project/commands/utility.py
@@ -65,7 +65,8 @@ class HzCommand(Command):
 @Command.register("seed", "hex", usage="seed")
 class SeedGenerationCommand(Command):
     def execute(self, *args):
-        self.check_moderator()
+        if self.context.platform == Platform.TWITCH:
+            self.check_moderator()
 
         seed = 0
         while (seed % 0x100 < 0x3):


### PR DESCRIPTION
I noticed in CTB they can't run "!seed" after this recent change: https://github.com/professor-l/classic-tetris-project/commit/d7468ede5be7ee7c5f0c00bb0380729f7c9ac934

I'm assuming this was to prevent confusion in Twitch chat.  But, this feels safe to allow in Discord I think?